### PR TITLE
[FIX] Revert base change

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,6 @@
 name: Deploy to GitHub Pages
 
 on:
-  workflow_dispatch:
   workflow_call:
 
 # Allow this job to clone the repo and create a page deployment

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ npm run dev
 ```
 Open the `localhost` link that appeared in your terminal, it should open a browser with a preview of the website. Each time you save a file, the website will update according to your changes.
 
+## Github pages deployment
+
+The documentation website is deployed on [scilus.github.io/nf-neuro](https://scilus.github.io/nf-neuro). To do so, the `github workflow` must run on the [main nf-neuro repository](https://github.com/scilus/nf-neuro). It is achieved using the `deploy.yml` **callable workflow** located in this repository and calling it in workflows located in the nf-neuro main repository. This way, the workflow runs in the correct context and can deploy correctly to the prescribed endpoint.
+
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,7 +16,7 @@ const rehypePlugins = [
 // https://astro.build/config
 export default defineConfig({
   site: "https://scilus.github.io",
-  base: "/nf-neuro-documentation",
+  base: "/nf-neuro",
   markdown: {
     smartypants: true,
     syntaxHighlight: "shiki",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "nf-neuro-documentation",
+  "name": "nf-neuro",
   "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "nf-neuro-documentation",
+      "name": "nf-neuro",
       "version": "0.0.5",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "https://github.com/scilus/nf-neuro-documentation"
   },
-  "homepage": "https://nf-neuro.scilus.github.io",
+  "homepage": "https://scilus.github.io/nf-neuro",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",


### PR DESCRIPTION
Base endpoint for the website deployment was changed to `nf-neuro-documentation`, but it breaks the deployment to `scilus.github.io/nf-neuro`. Reverted it to `/nf-neuro`.