### PR TITLE
Switch pnpm to npm for build in github action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,7 +61,7 @@ jobs:
         uses: withastro/action@v2
         with:
           node-version: 22
-          package-manager: pnpm@latest
+          package-manager: npm@latest
 
   deploy:
     needs: build


### PR DESCRIPTION
Astro's doc states that ppm does not install Sharp by default (even if it is in our lock file). We use it to preprocess images. (see https://docs.astro.build/en/reference/errors/missing-sharp/). Changed the package manager to `npm`, which should solve the issue.