### PR TITLE
Hotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,3 @@ The documentation website is deployed on [scilus.github.io/nf-neuro](https://sci
 ## License
 
 This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for details.
-
----
-
-Built by HYP3R00T. The source code is available on [GitHub](https://github.com/yourusername/celestialdocs). Crafted with ❤️ and care.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,6 +3,7 @@ import { defineConfig } from 'astro/config';
 import starlight from '@astrojs/starlight';
 import Icons from 'unplugin-icons/vite';
 import tailwindcss from '@tailwindcss/vite';
+import matomo from 'astro-matomo';
 
 // https://astro.build/config
 export default defineConfig({
@@ -112,7 +113,13 @@ export default defineConfig({
 					collapsed: true,
 				},
 			],
-    	})
+    	}),
+		matomo({
+            enabled: true,
+            host: 'https://scilus-nf-neuro.matomo.cloud',
+            siteId: 1,
+            disableCookies: true,
+        })
 	],
     vite: {
         plugins: [

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.32.2",
-    "@mdx-js/runtime": "1.6.22",
     "@iconify/json": "^2.2.315",
+    "@mdx-js/runtime": "1.6.22",
     "@tailwindcss/vite": "^4.0.13",
     "astro": "^5.4.3",
+    "astro-matomo": "^1.8.1",
     "pnpm": "^10.6.2",
     "sharp": "^0.32.6",
     "tailwindcss": "^4.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       astro:
         specifier: ^5.4.3
         version: 5.4.3(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.35.0)(terser@5.39.0)(typescript@5.8.2)(yaml@2.7.0)
+      astro-matomo:
+        specifier: ^1.8.1
+        version: 1.8.1(astro@5.4.3(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.35.0)(terser@5.39.0)(typescript@5.8.2)(yaml@2.7.0))
       pnpm:
         specifier: ^10.6.2
         version: 10.6.2
@@ -860,6 +863,11 @@ packages:
     resolution: {integrity: sha512-yJMQId0yXSAbW9I6yqvJ3FcjKzJ8zRL7elbJbllkv1ZJPlsI0NI83Pxn1YL1IapEM347EvOOkSW2GL+2+NO61w==}
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0
+
+  astro-matomo@1.8.1:
+    resolution: {integrity: sha512-ifSyb6Pw57cWiAPQB8Y2+mIFaKBxBMCcwmu2U1bJpTrMYTdw8bDyP1YfpzMgXdvFhXXWiOBYzgMb4TAfZTAQYg==}
+    peerDependencies:
+      astro: ^2.0.0-beta.0 || ^3.0.0 || ^4.0.0 || ^5.0.0
 
   astro@5.4.3:
     resolution: {integrity: sha512-GKkOJQCHLx6CrPoghGhj7824WDSvIuuc+HTVjfjMPdB9axp238iJLByREJNDaSdzMeR/lC13xvBiUnKvcYyEIA==}
@@ -3481,6 +3489,10 @@ snapshots:
     dependencies:
       astro: 5.4.3(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.35.0)(terser@5.39.0)(typescript@5.8.2)(yaml@2.7.0)
       rehype-expressive-code: 0.40.2
+
+  astro-matomo@1.8.1(astro@5.4.3(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.35.0)(terser@5.39.0)(typescript@5.8.2)(yaml@2.7.0)):
+    dependencies:
+      astro: 5.4.3(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.35.0)(terser@5.39.0)(typescript@5.8.2)(yaml@2.7.0)
 
   astro@5.4.3(@types/node@22.13.10)(jiti@2.4.2)(lightningcss@1.29.2)(rollup@4.35.0)(terser@5.39.0)(typescript@5.8.2)(yaml@2.7.0):
     dependencies:


### PR DESCRIPTION
Add integration to test matomo analytics.

Simple analytics does the job for quick visitation and retention metrics. However, it only keeps 30 days of statistics. Matomo allows us to host those metrics locally, so we have complete retention. We can also tailor the statistics we gather and do it without any cookies, which I really like.