### PR TITLE
Add section for pipelines documentation and link to nf-pediatric

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -141,6 +141,12 @@ export default defineConfig({
                             collapsed: true
                         }
                     ]
+                },
+                {
+                    label: 'Pipelines using nf-neuro',
+                    items: [
+                        { label: 'nf-pediatric', link: 'https://scilus.github.io/nf-pediatric/' },
+                    ]
                 }
             ]
         })


### PR DESCRIPTION
Just adding a link in the sidebar to the nf-pediatric documentation, we could add pipelines that use nf-neuro in this section. Happy to change the section title also, I was hesitating between 'Pipelines' or the current version.